### PR TITLE
Update gulp-minify-css dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "gulp": "^3.8.9",
     "gulp-concat": "^2.4.1",
     "gulp-sass": "^1.2.0",
-    "gulp-minify-css": "^0.3.11",
+    "gulp-minify-css": "^1.2.2",
     "gulp-uglify": "^1.0.1"
   }
 }


### PR DESCRIPTION
Minified css is different due to small things like 400ms being compressed to .4s.
Fixes #27 
