### PR TITLE
Meta for Twitter Summary Card with Large Image

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,10 @@
     <meta property="og:image" content="https://firstpr.me/images/open-graph/facebook-optimized-1200x630.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="First Pull Request">
+    <meta name="twitter:description" content="What was the first pull request you sent on GitHub?">
+    <meta name="twitter:image" content="https://firstpr.me/images/open-graph/facebook-optimized-1200x630.png">
   </head>
   <body class="first-pr">
 


### PR DESCRIPTION
I realised that current OG image is large enough to be used as Twitter Summary Card with Large Image. So, I created this PR.

Added meta for Twitter Summary Card with Large Image. https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image

Suggestion: Create a better image. The current OG image is may create confusion. It would be better if it is replaced by a generic one. 