### PR TITLE
fix: update how to contribute url

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
           <h2>
             It doesn't look like <a href="https://github.com/{{login}}">{{login}}</a> has sent a pull request yet.
           </h2>
-          <p><strong>Need help sending your first pull request?</strong> Check out <a href="https://guides.github.com/activities/contributing-to-open-source/">this handy guide.</a></p>
+          <p><strong>Need help sending your first pull request?</strong> Check out <a href="https://opensource.guide/how-to-contribute/">this handy guide.</a></p>
         </div>
       </div>
     </script>


### PR DESCRIPTION
Update how to contribute link from [this](https://guides.github.com/activities/contributing-to-open-source/) which is open the GitHub docs instead of the guides. The guide now is moved to [this link](https://opensource.guide/how-to-contribute/). 

Here is a preview when I tried to open the guide is redirected to GitHub docs
![firstpr redirect to gh docs](https://user-images.githubusercontent.com/43630681/183297791-f02ec422-4a81-4cd1-b376-47553cd7ac2a.gif)

