### PR TITLE
feat: add copy profile link button to results

### DIFF
--- a/firstpr.css
+++ b/firstpr.css
@@ -340,6 +340,20 @@ footer a, #all-results a {
   color: #666;
 }
 
+#copy-link-btn {
+  background: none;
+  border: 1px solid #999;
+  border-radius: 3px;
+  color: #666;
+  cursor: pointer;
+  font: inherit;
+  padding: 1px 6px;
+}
+
+#copy-link-btn:hover {
+  color: #333;
+}
+
 footer span, #all-results span {
   white-space: nowrap;
 }

--- a/firstpr.js
+++ b/firstpr.js
@@ -63,6 +63,7 @@ function renderFound(d) {
   '</div>' +
   '<div id="all-results">' +
     '<a href="https://github.com/search?q=author%3A' + d.user.login + '&type=pullrequests&s=created&o=asc" target="_blank">See every pull request</a> by <a href="' + d.user.html_url + '">' + d.user.login + '</a>' +
+    ' &bull; <button id="copy-link-btn" type="button">Copy profile link</button>' +
   '</div>';
 }
 
@@ -115,6 +116,12 @@ function loadData(login, cb){
 function renderData(pullRequestData){
   if(pullRequestData){
     main.innerHTML = renderFound(pullRequestData);
+    document.getElementById('copy-link-btn').addEventListener('click', function() {
+      navigator.clipboard.writeText(window.location.href);
+      this.textContent = 'Copied!';
+      var btn = this;
+      setTimeout(function(){ btn.textContent = 'Copy profile link'; }, 2000);
+    });
     document.querySelectorAll('.moment-date').forEach(function(dateElem){
       var time = new Date(dateElem.getAttribute('datetime'));
       var formatted = time.toLocaleString('en-US', {year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: '2-digit'});


### PR DESCRIPTION
Add a "Copy profile link" button to the results page so users can
easily share their firstpr.me profile URL on LinkedIn, GitHub bio,
or their resume.

Uses native navigator.clipboard API — no extra dependencies.
#1025 